### PR TITLE
chore: update konnector information after a migration from gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Cozy][cozy] <YOUR SUPER NEW KONNECTOR NAME>
+[Cozy][cozy] EDF konnector
 =======================================
 
 What's Cozy?
@@ -12,7 +12,7 @@ What's Cozy?
 What's this new konnector?
 --------------------------
 
-<YOUR DESCRIPTION HERE>
+A connector to retrieve your EDF bills and billing data and save them into your Cozy.
 
 ### Open a Pull-Request
 
@@ -82,7 +82,7 @@ You can reach the Cozy Community by:
 License
 -------
 
-<YOUR KONNECTOR NAME> is developed by <your name> and distributed under the [AGPL v3 license][agpl-3.0].
+cozy-konnector-edf is developed by [ptbrowne](https://github.com/ptbrowne) for Cozy Cloud and distributed under the [AGPL v3 license][agpl-3.0].
 
 [cozy]: https://cozy.io "Cozy Cloud"
 [agpl-3.0]: https://www.gnu.org/licenses/agpl-3.0.html

--- a/manifest.konnector
+++ b/manifest.konnector
@@ -4,16 +4,22 @@
   "type": "node",
   "slug": "edf",
   "description": "description",
-  "source": "git@gitlab.cozycloud.cc:gjacquart/connecteur-edf.git",
+  "source": "https://github.com/cozy/cozy-konnector-edf.git",
   "locales": {
     "fr": {
       "description": "Récupère toutes vos factures",
       "permissions": {
         "bills": {
-          "description": "Utilisé pour sauvegarder les données de facturation"
+          "description": "Utilisé pour sauvegarder les données de facturation EDF"
         },
         "files": {
-          "description": "Utilisé pour sauvegarder les factures"
+          "description": "Utilisé pour sauvegarder les factures EDF"
+        },
+        "contract": {
+          "description": "Utilisé pour sauvegarder vos contrats EDF"
+        },
+        "consumption": {
+          "description": "Utilisé pour sauvegarder vos rapports de consommation d'énergie EDF"
         }
       }
     }
@@ -57,7 +63,7 @@
     }
   },
   "developer": {
-    "name": "yourname",
-    "url": "your web site"
+    "name": "ptbrowne",
+    "url": "https://github.com/ptbrowne"
   }
 }


### PR DESCRIPTION
This project uses to be hosted on our internal gitlab server: https://gitlab.cozycloud.cc/ptbrowne/connecteur-edf.git